### PR TITLE
install/index.rst: More details on Single-Node-Setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - 2.6
-  - 3.3
+  - 2.7
+  - 3.4
 
 before_install:
   - sudo apt-get update -qq

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ MAKEINFO     := makeinfo
 
 BUILDDIR     := build
 SOURCE       := src/
-PAPERSIZE    := -D latex_paper_size=a4
+PAPERSIZE    := -D latex_elements.papersize=a4
 SPHINXFLAGS  := -a -W -n -A local=1 $(PAPERSIZE) -d $(BUILDDIR)/doctree
 SPHINXOPTS   := $(SPHINXFLAGS) $(SOURCE)
 

--- a/make.bat
+++ b/make.bat
@@ -7,14 +7,14 @@ if "%SPHINXBUILD%" == "" (
 )
 set BUILDDIR=build
 set SOURCE=src/
-set PAPERSIZE=-D latex_paper_size=a4
+set PAPERSIZE=-D latex_elements.papersize=a4
 set SPHINXFLAGS=-a -n -A local=1 %PAPERSIZE%
 set SPHINXOPTS=%SPHINXFLAGS% %SOURCE%
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS%
 set I18NSPHINXOPTS=%SPHINXOPTS%
 if NOT "%PAPER%" == "" (
-	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
-	set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
+	set ALLSPHINXOPTS=-D latex_elements.papersize=%PAPER% %ALLSPHINXOPTS%
+	set I18NSPHINXOPTS=-D latex_elements.papersize=%PAPER% %I18NSPHINXOPTS%
 )
 
 if "%1" == "" goto help

--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -141,8 +141,8 @@ improve configuration readability.
     This could be read as: "remove the `_all_dbs` parameter from the
     `httpd_global_handlers` section if it was ever set before".
 
-The semicolon (``;``) signs about `commentary` start: everything after this
-character is counted as commentary and doesn't process by CouchDB.
+The semicolon (``;``) signals the end of the parameter. Everything after this
+character is regarded as a comment and ignored by CouchDB.
 
 After editing of configuration file CouchDB server instance should be restarted
 to apply these changes.

--- a/src/install/index.rst
+++ b/src/install/index.rst
@@ -39,15 +39,18 @@ advantage of the new scaling and fault-tolerance features in CouchDB
 
 After installation and initial startup, visit Fauxton at
 ``http://127.0.0.01:5984/_utils#setup``. You will be asked to set up
-CouchDB as a single-node instance or set up a cluster.
-
-When you click “Single-Node-Setup”, you will get asked for an admin
-username and password. Choose them well and remember them. You can also
+CouchDB as a single-node instance or set up a cluster. When you
+click “Single-Node-Setup”, you will get asked for an admin username
+and password. Choose them well and remember them. You can also
 bind CouchDB to a public port, so it is accessible within your LAN or
-the public, if you are doing this on a public VM.
+the public, if you are doing this on a public VM. The wizard then configures
+your admin username and password and creates the three system databases
+_users, _replicator and _global_changes for you.
 
-When you run 2.0 as a single node, it doesn't create system databases
-on startup. You have to do this manually:
+Alternatively, if you don't want to use the  “Single-Node-Setup” wizard
+and run 2.0 as a single node with admin username and password already
+configured make sure to create the three three system databases
+manually on startup:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Stress the fact that the “Single-Node-Setup” creates the system databases for you. Add how single node setup can be done without using the wizard.